### PR TITLE
Consul Output 

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,8 @@ No Data is collected it is purely [github.com](https://github.com/Isan-Rivkin/su
 # How it Works 
 
 ![image info](./docs/surf-flow.png)
+
+# Contributors 
+
+* @AliRamberg  
+* @Isan-Rivkin

--- a/cmd/acm.go
+++ b/cmd/acm.go
@@ -25,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/acm"
 	"github.com/isan-rivkin/surf/lib/awsu"
 	search "github.com/isan-rivkin/surf/lib/search"
-	"github.com/isan-rivkin/surf/printer"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -58,10 +57,7 @@ var acmCmd = &cobra.Command{
 	surf acm -q some-acm-id --filter-id
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		s := &printer.SpinnerApi{}
-		t := printer.NewTablePrinter()
-		tui := printer.NewPrinter[printer.Loader, printer.Table](s, t)
-
+		tui := buildTUI()
 		auth, err := awsu.NewSessionInput(awsProfile, awsRegion)
 
 		if err != nil {

--- a/cmd/consul.go
+++ b/cmd/consul.go
@@ -77,16 +77,10 @@ Pattern matching against keys in Hasicorp Consul
 
 		tui.GetLoader().Start("searching consul", "", "green")
 
-		//pairs, err := client.List(*consulPrefix)
-
-		// if err != nil {
-		// 	log.WithError(err).Fatalf("failed listing all keys under the prefix %s", *consulPrefix)
-		// }
-
 		input := search.NewSearchInput(*consulQuery, *consulPrefix)
 
 		m := common.NewDefaultRegexMatcher()
-		s := search.NewSearcher[consul.ConsulClient, common.Matcher](client, m)
+		s := search.NewSearcher[consul.Client, common.Matcher](client, m)
 		output, err := s.Search(input)
 
 		tui.GetLoader().Stop()
@@ -129,13 +123,13 @@ Pattern matching against keys in Hasicorp Consul
 	},
 }
 
-func runConsulDefaultAuth() consul.ConsulClient {
+func runConsulDefaultAuth() consul.Client {
 	if *consulAddr == "" {
 		*consulAddr = os.Getenv("CONSUL_HTTP_ADDR")
 	}
 
 	client := consul.NewClient(*consulAddr, *consulDatacenter)
-	return *client
+	return client
 }
 
 func init() {

--- a/cmd/consul.go
+++ b/cmd/consul.go
@@ -128,7 +128,10 @@ func runConsulDefaultAuth() consul.Client {
 		*consulAddr = os.Getenv("CONSUL_HTTP_ADDR")
 	}
 
-	client := consul.NewClient(*consulAddr, *consulDatacenter)
+	client, err := consul.NewClient(*consulAddr, *consulDatacenter)
+	if err != nil {
+		log.WithError(err).Fatal("failed creating consul client")
+	}
 	return client
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	v "github.com/isan-rivkin/cliversioner"
+	"github.com/isan-rivkin/surf/printer"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -34,7 +35,6 @@ const (
 var (
 	cfgFile      string
 	verboseLevel *int
-	checkVersion *bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -52,6 +52,12 @@ var rootCmd = &cobra.Command{
 	// },
 }
 
+func buildTUI() printer.TuiController[printer.Loader, printer.Table] {
+	s := &printer.SpinnerApi{}
+	t := printer.NewTablePrinter()
+	tui := printer.NewPrinter[printer.Loader, printer.Table](s, t)
+	return tui
+}
 func getEnvOrOverride(flagVal *string, envName string) *string {
 	v := viper.GetString(envName)
 	if v != "" && *flagVal == "" {

--- a/lib/consul/consul.go
+++ b/lib/consul/consul.go
@@ -7,12 +7,21 @@ import (
 	c "github.com/hashicorp/consul/api"
 )
 
+type Client interface {
+	List(prefix string) (c.KVPairs, error)
+	GetSchemeType() string
+	GetConsulAddr() string
+	GetConsulUIBaseAddr() (string, error)
+	GetCurrentDatacenter() (string, error)
+	ListDatacenters() ([]string, error)
+}
+
 type ConsulClient struct {
 	client *c.Client
 	config *c.Config
 }
 
-func NewClient(address string, datacenter string) *ConsulClient {
+func NewClient(address string, datacenter string) Client {
 	config := c.Config{
 		Address:    address,
 		Datacenter: datacenter,

--- a/lib/consul/consul.go
+++ b/lib/consul/consul.go
@@ -21,16 +21,19 @@ type ConsulClient struct {
 	config *c.Config
 }
 
-func NewClient(address string, datacenter string) Client {
+func NewClient(address string, datacenter string) (Client, error) {
 	config := c.Config{
 		Address:    address,
 		Datacenter: datacenter,
 	}
-	client, _ := c.NewClient(&config)
+	client, err := c.NewClient(&config)
+	if err != nil {
+		return nil, err
+	}
 	return &ConsulClient{
 		client: client,
 		config: &config,
-	}
+	}, err
 }
 
 func (client *ConsulClient) List(prefix string) (c.KVPairs, error) {

--- a/lib/search/consulsearch/searcher.go
+++ b/lib/search/consulsearch/searcher.go
@@ -20,12 +20,12 @@ type Output struct {
 	Matches []string
 }
 
-type Searcher[C consul.ConsulClient, M common.Matcher] interface {
+type Searcher[C consul.Client, M common.Matcher] interface {
 	Search(i *Input) (*Output, error)
 }
 
-type DefaultSearcher[C consul.ConsulClient, M common.Matcher] struct {
-	Client     consul.ConsulClient
+type DefaultSearcher[C consul.Client, M common.Matcher] struct {
+	Client     consul.Client
 	Comparator common.Matcher
 }
 
@@ -36,8 +36,8 @@ func NewSearchInput(value string, basePath string) *Input {
 	}
 }
 
-func NewSearcher[C consul.ConsulClient, Comp common.Matcher](c consul.ConsulClient, m common.Matcher) Searcher[consul.ConsulClient, common.Matcher] {
-	return &DefaultSearcher[consul.ConsulClient, common.Matcher]{
+func NewSearcher[C consul.Client, Comp common.Matcher](c consul.Client, m common.Matcher) Searcher[consul.Client, common.Matcher] {
+	return &DefaultSearcher[consul.Client, common.Matcher]{
 		Client:     c,
 		Comparator: m,
 	}


### PR DESCRIPTION
Hi @AliRamberg  couple of changes:

1. I did the output, didn't really change anything from before, just added a table to summarize the result at the bottom + spinner while searching. 

2. Did some fixes that I only noticed now and missed during the review. The changes are: 

- Changed the `ConsulClient` struct into an interface, and changed all the **Generic** [references](https://github.com/Isan-Rivkin/surf/blob/30fe0f44f11932e3425d117086ec0bca22e145c3/lib/search/consulsearch/searcher.go#L23) to the interface. Not using an interface generally for a network-bound client is bad practice - hard to test. 
But **_the main issue_** here: in generics, not using an interface type completely misses the whole point of using generics. 

- Changed `GetConsulAddr`  [function](https://github.com/Isan-Rivkin/surf/blob/30fe0f44f11932e3425d117086ec0bca22e145c3/lib/consul/consul.go#L29), it would break for most people who are not me and you. 
