### PR TITLE
Feature: added support for multiple aws sessions in parallel + Bug Fixes

### DIFF
--- a/cmd/r53.go
+++ b/cmd/r53.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/isan-rivkin/surf/lib/awsu"
@@ -25,6 +25,7 @@ import (
 )
 
 var (
+	r53MultipleProfiles    string
 	recusiveSearchMaxDepth *int
 	recordInput            *string
 	awsProfile             string
@@ -34,27 +35,51 @@ var (
 
 // r53Cmd represents the r53 command
 var r53Cmd = &cobra.Command{
-	Use:   "r53 -q '*.some.dns.record.com'\n",
+	Use:   `r53 -q <dns-record>`,
 	Short: "Query route53 to get your dns record values",
-	Long: `Query Route53 to get all sorts of information about a dns record.
-	r53 will use your default AWS credentials`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("r53 called")
+	Long: `
+	Query Route53 to get all sorts of information about a dns record.
+	
+	=== search the target of '*.address.com' ===
 
+	$surf r53 -q '*.address.com'
+
+	=== skip Name Server validation (NS records)  ===
+
+	$surf r53 -q '*.address.com' --ns-skip 
+
+	=== search the target of '*.address.com' in multiple AWS profiles ===
+
+	$surf r53 -q '*.address.com'  --aws-profiles default,prod,dev
+
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
 		debug := false
 		recurse := true
-		in, err := awsu.NewR53Input(aws.StringValue(recordInput), awsProfile, debug, muteR53Logs, skipNSVerification, recurse, *recusiveSearchMaxDepth)
-
-		if err != nil {
-
-			log.WithError(err).Fatal("failed creating r53 input")
+		// TODO(multiple aws account not consolidated)
+		var awsProfiles []string
+		if r53MultipleProfiles != "" {
+			awsProfiles = strings.Split(r53MultipleProfiles, ",")
+		} else {
+			awsProfiles = append(awsProfiles, awsProfile)
 		}
-		_, err = awsu.SearchRoute53(in)
-
-		if err != nil {
-			log.WithError(err).Fatal("failed searching r53")
+		if len(awsProfiles) < 1 {
+			log.Fatal("no aws profiles provided")
 		}
 
+		for _, awsProf := range awsProfiles {
+			in, err := awsu.NewR53Input(aws.StringValue(recordInput), awsProf, debug, muteR53Logs, skipNSVerification, recurse, *recusiveSearchMaxDepth)
+
+			if err != nil {
+
+				log.WithError(err).Fatal("failed creating r53 input")
+			}
+			_, err = awsu.SearchRoute53(in)
+
+			if err != nil {
+				log.WithError(err).Errorf("failed searching r53 in profile %s", awsProf)
+			}
+		}
 	},
 }
 
@@ -64,6 +89,7 @@ func init() {
 	r53Cmd.PersistentFlags().StringVarP(&awsProfile, "profile", "p", getDefaultProfileEnvVar(), "~/.aws/credentials chosen account")
 	r53Cmd.PersistentFlags().BoolVar(&muteR53Logs, "mute-logs", false, "if flag set then logs from route53-cli sdk will be muted")
 	r53Cmd.PersistentFlags().BoolVar(&skipNSVerification, "ns-skip", false, "if set then nameservers will not be verified against the hosted zone result")
+	r53Cmd.PersistentFlags().StringVar(&r53MultipleProfiles, "aws-profiles", "", "search in multiple aws profiles (comma separated: --aws-profiles prod,dev,staging) overrides --profile")
 	maxDepth := 3
 	r53Cmd.PersistentFlags().IntVarP(&maxDepth, "max-depth", "d", maxDepth, "if -R is used then specifies when to stop recursive search depth")
 	recusiveSearchMaxDepth = &maxDepth

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	AppVersion = "2.1.2"
+	AppVersion = "2.2.2"
 	AppName    = "surf"
 )
 

--- a/lib/awsu/auth.go
+++ b/lib/awsu/auth.go
@@ -14,9 +14,27 @@ import (
 )
 
 type AuthInput struct {
-	Provider        client.ConfigProvider
-	Configs         []*aws.Config
-	EffectiveRegion string
+	Provider         client.ConfigProvider
+	Configs          []*aws.Config
+	EffectiveRegion  string
+	EffectiveProfile string
+}
+
+type AWSSessionInput struct {
+	Profile string
+	Region  string
+}
+
+func NewSessionInputMatrix(inputs []*AWSSessionInput) ([]*AuthInput, error) {
+	var out []*AuthInput
+	for _, input := range inputs {
+		auth, err := NewSessionInput(input.Profile, input.Region)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, auth)
+	}
+	return out, nil
 }
 
 func NewSessionInput(profile, region string) (*AuthInput, error) {
@@ -33,7 +51,7 @@ func NewSessionInput(profile, region string) (*AuthInput, error) {
 	}
 	conf := []*aws.Config{c}
 
-	return &AuthInput{Provider: sess, Configs: conf, EffectiveRegion: effectiveRegion}, nil
+	return &AuthInput{Provider: sess, Configs: conf, EffectiveRegion: effectiveRegion, EffectiveProfile: profile}, nil
 }
 
 func NewACM(in *AuthInput) (*acm.ACM, error) {

--- a/lib/search/s3search/searcher.go
+++ b/lib/search/s3search/searcher.go
@@ -126,8 +126,8 @@ func (s *DefaultSearcher[CC, Matcher]) Search(i *Input) (*Output, error) {
 						res.Keys = append(res.Keys, aws.StringValue(k.Key))
 					}
 				}
-				asyncResults <- res
 			}
+			asyncResults <- res
 		})
 	}
 
@@ -135,19 +135,17 @@ func (s *DefaultSearcher[CC, Matcher]) Search(i *Input) (*Output, error) {
 	size := len(targetBuckets)
 	counter := 1
 	for r := range asyncResults {
-		if r.Err != nil {
-			log.WithError(err).WithField("bucket", r.Bucket).Error("failed describing keys")
-			continue
-		}
+		counter++
 
-		filteredResult.BucketToMatches[r.Bucket] = r.Keys
+		if r.Err != nil {
+			log.WithError(r.Err).WithField("bucket", r.Bucket).Error("failed searching keys in bucket (potential fix: sure the target bucket is in the target region)")
+		} else {
+			filteredResult.BucketToMatches[r.Bucket] = r.Keys
+		}
 
 		if counter >= size {
 			break
 		}
-
-		counter++
 	}
-
 	return filteredResult, nil
 }


### PR DESCRIPTION
# What's New

### Parallel search in multiple AWS profiles/regions 
- Supported in all AWS sub commands, `r53, s3, ddb, acm`. 
- Usage: `--aws-session profile1,region2 --aws-session profile2,region3` 
- Note: `--profile, --region` still supported but `--aws-session` will override them if set.

# Bug Fixed
- Correct error handling in `s3` search. 
